### PR TITLE
Add codespell to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,8 @@ repos:
     hooks:
       - id: yamllint
         args: [--config-file=.github/linters/.yamllint.yaml]
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,6 @@ repos:
         args: [--config-file=.github/linters/.yamllint.yaml]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Salam Organization Front Page 
+# Salam Organization Front Page
 
-https://github.com/SalamLang/.github/tree/main/profile#readme
+<https://github.com/SalamLang/.github/tree/main/profile#readme>

--- a/profile/README.md
+++ b/profile/README.md
@@ -21,7 +21,7 @@ In Iran, Afghanistan, Azerbaijan and Tajikistan, Salâm (سلام) is used alone
         </a>
       </td>
       <td align="center">
-        <a href="https://github.com/jbampton"> 
+        <a href="https://github.com/jbampton">
           <img src="https://avatars.githubusercontent.com/u/418747?s=250&v=4" alt="John Bampton"><br>
           <strong>Co-founder, Community Leader and Scrum Master 🏢</strong><br>
           John Bampton  


### PR DESCRIPTION
Adds codespell hook to catch spelling errors.

Other changes (trailing whitespace, markdown formatting) were automatically fixed by pre-commit hooks.

Fixes #20