### PR TITLE
Add markdown link checker to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,9 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
+
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.14.0
+    hooks:
+      - id: markdown-link-check
+        args: [-q]


### PR DESCRIPTION
Adds markdown-link-check hook to validate all links in markdown files automatically.

Closes #19